### PR TITLE
Fix UI Changes on Revisions and replicas option in container app and fix Container Image port

### DIFF
--- a/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
+++ b/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
@@ -1085,7 +1085,7 @@ Complete the following steps to configure labels on the revisions.
 
     - Insecure connections: ensure that Allowed is **NOT** checked.
 
-    - Target port: enter **80**
+    - Target port: enter **5000**
 
     - IP Security Restrictions Mode: ensure that **Allow all traffic** is selected.
 

--- a/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
+++ b/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
@@ -1036,7 +1036,7 @@ Complete the following steps to set revision management to multiple.
 
 1. In the Azure portal, open your container app resource.
 
-1. On the left side menu, under Application, select **Revisions**.
+1. On the left side menu, under Application, select **Revisions and replicas**.
 
 1. At the top of the Revisions page, select **Choose revision mode**.
 
@@ -1091,7 +1091,7 @@ Complete the following steps to configure labels on the revisions.
 
 1. At the bottom of the Ingress page, select **Save**, and then wait for the update to complete.
 
-1. On the left-side menu, under Revisions, select **Revisions**.
+1. On the left-side menu, under Revisions, select **Revisions and replicas**.
 
 1. For the v2 revision, under Label, enter **updated**
 

--- a/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
+++ b/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
@@ -842,13 +842,11 @@ Complete the following steps to configure HTTP scale rules for your Container Ap
 
 1. Ensure that your Container App is open in the portal.
 
-1. On the left-side menu under Application, select **Revisions**.
+1. On the left-side menu under Application, select **Revisions and replicas**.
 
 1. Notice the Name assigned to your active revision.
 
-1. On the left-side menu under Application, select **Scale and replicas**.
-
-1. To the right of Revision, ensure that your active revision is selected.
+1. On the left-side menu under Application, select **Scale**.
 
 1. At the top of the page, select **Edit and deploy**.
 


### PR DESCRIPTION
Changes proposed in this pull request:

- The Container App page in the Azure portal now has the option **Revisions and replicas**. In the instructions there is the old name.
- Exercise 07, Task 03 , Step 03: the instructions tell to set port 80 for the Ingress. The container images was created exposed the port 5000. If you set port 80 you receive the following error when you try to navigate to the Container App URL:

![image](https://github.com/MicrosoftLearning/az-2003-deploy-cloud-native-applications-using-azure-container-apps/assets/9560142/ee9d1692-9867-4da5-8af1-255dec65bd16)

If you set as port 500, you receive the "Hello World" message:

![image](https://github.com/MicrosoftLearning/az-2003-deploy-cloud-native-applications-using-azure-container-apps/assets/9560142/33f1905c-6908-444c-a69f-79c4bbc8902a)

