### PR TITLE
Backfill missing lab metadata (2 files)

### DIFF
--- a/Instructions/Labs/01-containerapps-advanced.md
+++ b/Instructions/Labs/01-containerapps-advanced.md
@@ -1,9 +1,14 @@
 ---
 lab:
-    title: 'Deploy and Operate Azure Container Apps'
-    description: 'Deploy Azure Container Apps infrastructure using Bicep, build container images, implement auto-scaling, traffic splitting, batch processing jobs, and CI/CD with Azure DevOps'
-    level: 300
-    Duration: 150 minutes
+  title: Deploy and Operate Azure Container Apps
+  description: Deploy Azure Container Apps infrastructure using Bicep, build container images, implement auto-scaling, traffic splitting, batch processing jobs, and CI/CD with Azure DevOps
+  level: 300
+  duration: 150 minutes
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Container Apps
+    - Azure DevOps
 ---
 
 # Deploy and Operate Azure Container Apps

--- a/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
+++ b/Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md
@@ -1,8 +1,15 @@
 ---
 lab:
-    title: 'Lab: Deploy and manage a container app using Azure Container Apps'
-    type: 'Answer Key'
-    module: 'Module 6: Deploy and manage a container app using Azure Container Apps'
+  title: 'Lab: Deploy and manage a container app using Azure Container Apps'
+  type: Answer Key
+  module: 'Module 6: Deploy and manage a container app using Azure Container Apps'
+  description: In this exercise, you'll configure Azure resources that support your Azure Container Apps solution.
+  duration: 15 minutes
+  level: 500
+  islab: true
+  primarytopics:
+    - Azure
+    - Azure Container Apps
 ---
 
 # Lab: Deploy and manage a container app using Azure Container Apps


### PR DESCRIPTION
This PR backfills missing lab metadata in markdown files.

Rules used:
- Add-only (does not overwrite existing metadata keys)
- Keys: lab.title, lab.description, lab.duration, lab.level, lab.islab
- Optional casing normalization to lowercase when enabled

Files changed: 2

- `Instructions/Labs/01-containerapps-advanced.md` (normalized_case_keys,islab,primarytopics)
- `Instructions/Labs/LAB_AK_01_deploy_manage_container_app_azure_container_apps.md` (description,duration,level,islab,primarytopics)
